### PR TITLE
Add --disable-warnings-as-errors option to build_labsjdk.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ python build_labsjdk.py
 This will produce a labsjdk installation under `build/labsjdks/release` along with 2 archives in the same
 directory; one for the JDK itself and a separate one for the debug symbols.
 
+NOTE: if you want to pass options for `configure` in OpenJDK, you can pass the file location which lists them in each line to `--configure-options` on `build_labsjdk.py`.
+
 You can verify the labsjdk build with:
 ```
 ./build/labsjdks/release/java_home/bin/java -version

--- a/build_labsjdk.py
+++ b/build_labsjdk.py
@@ -261,6 +261,7 @@ def main():
     parser.add_argument('--jdk-debug-level', action='store', help='value for --with-debug-level JDK config option', default='release', choices=['release', 'fastdebug','slowdebug'])
     parser.add_argument('--devkit', action='store', help='value for --with-devkit configure option', default=env.get('DEVKIT', ''), metavar='<path>')
     parser.add_argument('--jvmci-version', action='store', help='JVMCI version (e.g., 19.3-b03)', metavar='<version>')
+    parser.add_argument('--disable-warnings-as-errors', action='store_true', help='do not consider compiler warnings to be an errors')
 
     opts = parser.parse_args()
     build_os = get_os()
@@ -311,11 +312,14 @@ def main():
         "--with-version-opt=" + "jvmci-" + jvmci_version,
         "--with-version-pre="
     ]
-    if build_arch != 'aarch64':
-        configure_options.append("--disable-precompiled-headers")
-    if is_musl(build_os):
-        # If we are building on musl, some warnings are produced which would abort the compilation
+    if opts.disable_warnings_as_errors:
         configure_options.append("--disable-warnings-as-errors")
+    else:
+        if build_arch != 'aarch64':
+            configure_options.append("--disable-precompiled-headers")
+        if is_musl(build_os):
+            # If we are building on musl, some warnings are produced which would abort the compilation
+            configure_options.append("--disable-warnings-as-errors")
 
     check_call(["sh", "configure"] + configure_options, cwd=jdk_src_dir)
     check_call([opts.make, "LOG=info", "CONF=" + conf_name, "product-bundles", "static-libs-bundles"], cwd=jdk_src_dir)

--- a/build_labsjdk.py
+++ b/build_labsjdk.py
@@ -261,7 +261,7 @@ def main():
     parser.add_argument('--jdk-debug-level', action='store', help='value for --with-debug-level JDK config option', default='release', choices=['release', 'fastdebug','slowdebug'])
     parser.add_argument('--devkit', action='store', help='value for --with-devkit configure option', default=env.get('DEVKIT', ''), metavar='<path>')
     parser.add_argument('--jvmci-version', action='store', help='JVMCI version (e.g., 19.3-b03)', metavar='<version>')
-    parser.add_argument('--disable-warnings-as-errors', action='store_true', help='do not consider compiler warnings to be an errors')
+    parser.add_argument('--configure-options', action='store', help='Reads and passes options to configure script from a specified file.', metavar='<path>')
 
     opts = parser.parse_args()
     build_os = get_os()
@@ -312,11 +312,16 @@ def main():
         "--with-version-opt=" + "jvmci-" + jvmci_version,
         "--with-version-pre="
     ]
-    # If we are building on musl, some warnings are produced which would abort the compilation
-    if opts.disable_warnings_as_errors or is_musl(build_os):
-        configure_options.append("--disable-warnings-as-errors")
     if build_arch != 'aarch64':
         configure_options.append("--disable-precompiled-headers")
+    if is_musl(build_os):
+        # If we are building on musl, some warnings are produced which would abort the compilation
+        configure_options.append("--disable-warnings-as-errors")
+
+    if opts.configure_options:
+        with open(opts.configure_options, 'r') as conf:
+            for line in conf:
+                configure_options.append(line)
 
     check_call(["sh", "configure"] + configure_options, cwd=jdk_src_dir)
     check_call([opts.make, "LOG=info", "CONF=" + conf_name, "product-bundles", "static-libs-bundles"], cwd=jdk_src_dir)

--- a/build_labsjdk.py
+++ b/build_labsjdk.py
@@ -312,14 +312,11 @@ def main():
         "--with-version-opt=" + "jvmci-" + jvmci_version,
         "--with-version-pre="
     ]
-    if opts.disable_warnings_as_errors:
+    # If we are building on musl, some warnings are produced which would abort the compilation
+    if opts.disable_warnings_as_errors or is_musl(build_os):
         configure_options.append("--disable-warnings-as-errors")
-    else:
-        if build_arch != 'aarch64':
-            configure_options.append("--disable-precompiled-headers")
-        if is_musl(build_os):
-            # If we are building on musl, some warnings are produced which would abort the compilation
-            configure_options.append("--disable-warnings-as-errors")
+    if build_arch != 'aarch64':
+        configure_options.append("--disable-precompiled-headers")
 
     check_call(["sh", "configure"] + configure_options, cwd=jdk_src_dir)
     check_call([opts.make, "LOG=info", "CONF=" + conf_name, "product-bundles", "static-libs-bundles"], cwd=jdk_src_dir)


### PR DESCRIPTION
I'd like to introduce `--disable-warnings-as-errors` to `build_labsjdk.py`.

I tried to build LabsJDK CE 11 on Fedora 32 which is installed GCC 10.1.1, but GCC reported some warnings, and they were considered to be errors.

configure script in OpenJDK has `--disable-warnings-as-errors` option to avoid them, so I want to pass it from `build_labsjdk.py`.