### PR TITLE
jhsdb does not work with coredump which comes from Substrate VM

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/ps_core.c
@@ -724,6 +724,7 @@ static bool read_lib_segments(struct ps_prochandle* ph, int lib_fd, ELF_EHDR* li
         // rounded up to page boundary.
         if ((strcmp(LIBC, "musl")) &&
             (existing_map->memsz != page_size) &&
+            (existing_map->fd != ph->core->core_fd) &&
             (existing_map->fd != lib_fd) &&
             (ROUNDUP(existing_map->memsz, page_size) != ROUNDUP(lib_php->p_memsz, page_size))) {
 


### PR DESCRIPTION
I played Truffle NFI on GraalVM, but I cannot get Java stacks from coredump via jhsdb.

I've reported this issue in https://github.com/oracle/graal/issues/2579 , and I 've found out the cause of this issue is `.svm_heap` would be separated to RO and RW areas by `mprotect()` calls in run time in spite of `.svm_heap` is RO section in ELF.

I think it is not a bug in SA, so I think it should be fixed in LabsJDK instead of upstream because it is used for a base of GraalVM.
Substrate VM would not seem to be fixed (and it would be big change for SVM if it is fixed!).