### PR TITLE
Improving XSLT support for Native Image.

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/LiteralElement.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/LiteralElement.java
@@ -33,6 +33,7 @@ import com.sun.org.apache.xml.internal.serializer.ElemDesc;
 import com.sun.org.apache.xml.internal.serializer.ToHTMLStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
@@ -202,7 +203,7 @@ final class LiteralElement extends Instruction {
      * to _ANY_ namespace URI. Used by literal result elements to determine
      */
     public Set<Map.Entry<String, String>> getNamespaceScope(SyntaxTreeNode node) {
-        Map<String, String> all = new HashMap<>();
+        Map<String, String> all = new LinkedHashMap<>();
 
         while (node != null) {
             Map<String, String> mapping = node.getPrefixMapping();

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Mode.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Mode.java
@@ -48,6 +48,7 @@ import com.sun.org.apache.xml.internal.dtm.Axis;
 import com.sun.org.apache.xml.internal.dtm.DTM;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -130,12 +131,12 @@ final class Mode implements Constants {
     /**
      * A mapping between templates and test sequences.
      */
-    private Map<Template, Object> _neededTemplates = new HashMap<>();
+    private Map<Template, Object> _neededTemplates = new LinkedHashMap<>();
 
     /**
      * A mapping between named templates and Mode objects.
      */
-    private Map<Template, Mode> _namedTemplates = new HashMap<>();
+    private Map<Template, Mode> _namedTemplates = new LinkedHashMap<>();
 
     /**
      * A mapping between templates and instruction handles.
@@ -198,7 +199,7 @@ final class Mode implements Constants {
 
     public String functionName(int min, int max) {
         if (_importLevels == null) {
-            _importLevels = new HashMap<>();
+            _importLevels = new LinkedHashMap<>();
         }
         _importLevels.put(max, min);
         return _methodName + '_' + max;
@@ -1053,8 +1054,8 @@ final class Mode implements Constants {
         final List<String> names = xsltc.getNamesIndex();
 
         // Clear some datastructures
-        _namedTemplates = new HashMap<>();
-        _neededTemplates = new HashMap<>();
+        _namedTemplates = new LinkedHashMap<>();
+        _neededTemplates = new LinkedHashMap<>();
         _templateIHs = new HashMap<>();
         _templateILs = new HashMap<>();
         _patternGroups = (List<LocationPathPattern>[])new ArrayList[32];

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/Number.java
@@ -594,4 +594,9 @@ final class Number extends Instruction implements Closure {
                                  CHARACTERSW_SIG);
         il.append(new INVOKEVIRTUAL(index));
     }
+
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MethodGenerator.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/MethodGenerator.java
@@ -67,6 +67,7 @@ import com.sun.org.apache.xalan.internal.xsltc.compiler.XSLTC;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -283,7 +284,7 @@ public class MethodGenerator extends MethodGen
         /**
          * Maps a name to a {@link LocalVariableGen}
          */
-        protected Map<String, Object> _nameToLVGMap = new HashMap<>();
+        protected Map<String, Object> _nameToLVGMap = new LinkedHashMap<>();
 
         /**
          * Registers a {@link org.apache.bcel.generic.LocalVariableGen}
@@ -1354,8 +1355,8 @@ public class MethodGenerator extends MethodGen
         // to local variables in the outlined method.
         HashMap<LocalVariableGen, LocalVariableGen> localVarMap = new HashMap<>();
 
-        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarStart = new HashMap<>();
-        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarEnd = new HashMap<>();
+        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarStart = new LinkedHashMap<>();
+        HashMap<LocalVariableGen, InstructionHandle> revisedLocalVarEnd = new LinkedHashMap<>();
 
         // Pass 1: Make copies of all instructions, append them to the new list
         // and associate old instruction references with the new ones, i.e.,


### PR DESCRIPTION
Currently, XSLT is not working for GraalVM's Native Image (NI). 

The NI agent is registering dynamically generated classes that we then use during NI build. Each of these classes will have its unique hash created upon bytecode.

If the bytecode of classes dynamically generated during the NI run is differing from its pair classes caught by the agent, the execution will fail here: https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/PredefinedClassesSupport.java#L127-L131. 

There are two reasons for this bytecode output instability:

- Methods like ` .values` and `.keySet` called from `HashMap` can result in different traversal orders of its elements.
- `toString` default implementation includes class name and random hash. This random hash is different in two consecutive execution.